### PR TITLE
Update test gateway (verify method)

### DIFF
--- a/src/Gateways/Test/TestGateway.php
+++ b/src/Gateways/Test/TestGateway.php
@@ -92,7 +92,7 @@ class TestGateway extends AbstractGateway implements GatewayInterface
 
     public function verify(): void
     {
-        if ($this->request['status'] ?? null === 'error') {
+        if (($this->request['status'] ?? null) === 'error') {
             throw TestException::error(-100);
         }
 


### PR DESCRIPTION
If there was a request with the status name, then the equality check with the word error was not done